### PR TITLE
fix: Update package.json exports field to include Svelte source path

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
   "bugs": {
     "url": "https://github.com/GCBenlloch/svelte-cleavejs/issues"
   },
-  "svelte": "src/index.js",
+  "exports": {
+    ".": {
+      "svelte": "src/index.js"
+    }
+  },
   "module": "dist/index.mjs",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request aims to address vite warnings regarding missing exports condition

> [vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.